### PR TITLE
Fix signal updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -459,14 +459,14 @@ version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd125be87bf4c255ebc50de0b7f4d2a6201e8ac3dc86e39c0ad081dc5e7236fe"
 dependencies = [
- "clap 4.1.6",
+ "clap 4.1.8",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3659,7 +3659,7 @@ checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
- "clap 4.1.6",
+ "clap 4.1.8",
  "duct",
  "itertools",
  "scopeguard",
@@ -3674,7 +3674,7 @@ source = "git+https://github.com/simon-bourne/rust-xtask-base#e1764245e676cd9aba
 dependencies = [
  "cargo_metadata",
  "chrono",
- "clap 4.1.6",
+ "clap 4.1.8",
  "clap_complete",
  "duct",
  "execute",

--- a/packages/silkenweb/src/node.rs
+++ b/packages/silkenweb/src/node.rs
@@ -2,8 +2,6 @@
 
 use std::fmt;
 
-use discard::DiscardOnDrop;
-use futures_signals::CancelableFutureHandle;
 use silkenweb_signals_ext::value::Value;
 
 use crate::dom::{
@@ -20,7 +18,7 @@ pub use component::Component;
 /// A DOM Node
 pub struct Node<D: Dom = DefaultDom> {
     node: D::Node,
-    resources: Vec<Resource>,
+    resources: ResourceVec,
     events: EventStore,
 }
 
@@ -77,5 +75,8 @@ pub fn text<D: Dom>(text: &str) -> Text<D> {
     Text(D::Text::new(text))
 }
 
-/// A resource that needs to be held
-type Resource = DiscardOnDrop<CancelableFutureHandle>;
+trait Resource {}
+
+impl<T> Resource for T {}
+
+type ResourceVec = Vec<Box<dyn Resource>>;

--- a/packages/xtask/Cargo.toml
+++ b/packages/xtask/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = "4.0.4"
+clap = "4.1.8"
 xtask-base = { git = "https://github.com/simon-bourne/rust-xtask-base" }
 xshell = "0.1.17"
 duct = "0.13.5"


### PR DESCRIPTION
The child signal future handles were only held in the parent signal future, so they were cancelled when the parent signal future completed. We now hang onto the child signal resources in the element as well.