### PR TITLE
Release improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "oorandom",
+ "plotters",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -1963,6 +1965,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,8 +632,6 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -1963,34 +1961,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "plotters"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "silkenweb-bootstrap"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "derive_more",
  "futures-signals",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "silkenweb-htmx-axum"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,10 +1081,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2761,7 +2759,6 @@ dependencies = [
 name = "silkenweb-example-css-modules"
 version = "0.1.0"
 dependencies = [
- "futures-signals",
  "silkenweb",
 ]
 
@@ -2829,7 +2826,6 @@ dependencies = [
 name = "silkenweb-example-reactive-styles"
 version = "0.1.0"
 dependencies = [
- "futures-signals",
  "silkenweb",
 ]
 
@@ -2837,7 +2833,6 @@ dependencies = [
 name = "silkenweb-example-router"
 version = "0.1.0"
 dependencies = [
- "futures-signals",
  "silkenweb",
 ]
 
@@ -2872,9 +2867,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "derive_more",
- "discard",
  "futures-signals",
- "js-sys",
  "serde",
  "serde_json",
  "silkenweb",
@@ -2899,8 +2892,6 @@ name = "silkenweb-js-framework-benchmark"
 version = "0.1.0"
 dependencies = [
  "futures-signals",
- "getrandom",
- "js-sys",
  "rand 0.8.5",
  "silkenweb",
  "wasm-bindgen",
@@ -2910,7 +2901,6 @@ dependencies = [
 name = "silkenweb-macros"
 version = "0.4.0"
 dependencies = [
- "cssparser",
  "derive_more",
  "grass",
  "lightningcss",
@@ -2947,7 +2937,6 @@ name = "silkenweb-tauri-proc-macro"
 version = "0.4.0"
 dependencies = [
  "proc-macro-error",
- "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "include-doc",
  "js-sys",
  "pin-project",
- "reqwasm 0.5.0",
+ "reqwasm",
  "serde",
  "serde_json",
  "slotmap",
@@ -2326,26 +2326,6 @@ dependencies = [
 
 [[package]]
 name = "reqwasm"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee625fb8e28ee1dac344e1d135c3b9815ddd5b44b3062cb69fe83168e5225a10"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwasm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b89870d729c501fa7a68c43bf4d938bbb3a8c156d333d90faa0e8b3e3212fb"
@@ -2679,7 +2659,7 @@ name = "silkenweb-example-async-http-request"
 version = "0.1.0"
 dependencies = [
  "futures-signals",
- "reqwasm 0.4.1",
+ "reqwasm",
  "silkenweb",
 ]
 
@@ -2694,7 +2674,7 @@ dependencies = [
  "axum",
  "futures",
  "futures-signals",
- "reqwasm 0.5.0",
+ "reqwasm",
  "serde",
  "silkenweb",
  "tokio",
@@ -2757,7 +2737,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-signals",
- "reqwasm 0.4.1",
+ "reqwasm",
  "serde",
  "silkenweb",
  "timeago",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,8 +1079,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2842,6 +2844,7 @@ name = "silkenweb-js-framework-benchmark"
 version = "0.1.0"
 dependencies = [
  "futures-signals",
+ "getrandom",
  "rand 0.8.5",
  "silkenweb",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,83 @@ lto = true
 opt-level = "z"
 
 [profile.bench]
-opt-level=3
+opt-level = 3
+
+# Defines the versions for all the workspace dependencies, including examples
+# but does not specify features, which is done in each crate as needed
+[workspace.dependencies]
+
+# main dependencies
+js-sys = "0.3.60"
+web-sys = "0.3.60"
+wasm-bindgen = "=0.2.84"
+wasm-bindgen-futures = "0.4.33"
+cssparser = "0.29.6"
+lightningcss = "=1.0.0-alpha.42"
+itertools = "0.10.5"
+silkenweb = { path = "packages/silkenweb" }
+silkenweb-base = { path = "packages/base", version = "0.4.0" }
+silkenweb-signals-ext = { path = "packages/signals-ext", version = "0.4.0" }
+silkenweb-macros = { path = "packages/macros", version = "0.4.0" }
+silkenweb-tauri-proc-macro = { path = "packages/tauri-proc-macro", version = "0.4.0" }
+async-trait = "0.1.66"
+axum = "0.6.10"
+serde = "1.0.154"
+serde_urlencoded = "0.7.1"
+serde-wasm-bindgen = "0.4.5"
+futures-signals = "0.3.31"
+pin-project = "1.0.12"
+paste = "1.0.9"
+discard = "1.0.4"
+futures = "0.3.24"
+caseless = "0.2.1"
+html-escape = "0.2.9"
+indexmap = "1.8.0"
+console_error_panic_hook = "0.1.7"
+static_assertions = "1.1.0"
+tokio = "1.25.0"
+
+# macro dependencies
+syn = "1.0.86"
+proc-macro-error = "1.0.4"
+quote = "1.0.15"
+proc-macro2 = "1.0.36"
+heck = "0.4.0"
+derive_more = "0.99.17"
+grass = "0.12.4"
+
+# xtask dependencies
+clap = "4.1.8"
+xtask-base = { git = "https://github.com/simon-bourne/rust-xtask-base" }
+xshell = "0.1.17"
+duct = "0.13.5"
+scopeguard = "1.1.0"
+
+# Example dependencies
+chrono = "0.4.19"
+timeago = "0.3.0"
+async-recursion = "1.0.0"
+silkenweb-htmx-axum = { path = "packages/htmx-axum" }
+web-log = "1.0.1"
+rand = "0.8.5"
+getrandom = "0.2.7"
+serde_json = "1.0.85"
+parse-display = "0.8.0"
+silkenweb-bootstrap = { path = "packages/bootstrap" }
+silkenweb-bootstrap-macros = { path = "packages/bootstrap/macros" }
+gloo-console = "0.2.3"
+# TODO: upgrade to 0.5 and update examples/client-server
+reqwasm = "0.4.1"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
+num-traits = "0.2.15"
+
+arpy = { git = "https://github.com/simon-bourne/arpy" }
+arpy-reqwasm = { git = "https://github.com/simon-bourne/arpy" }
+arpy-server = { git = "https://github.com/simon-bourne/arpy" }
+arpy-axum = { git = "https://github.com/simon-bourne/arpy" }
+
+# test dependencies
+wasm-bindgen-test = "0.3.28"
+criterion = "0.4.0"
+trybuild = "1.0.76"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,7 @@ parse-display = "0.8.0"
 silkenweb-bootstrap = { path = "packages/bootstrap" }
 silkenweb-bootstrap-macros = { path = "packages/bootstrap/macros" }
 gloo-console = "0.2.3"
-# TODO: upgrade to 0.5 and update examples/client-server
-reqwasm = "0.4.1"
+reqwasm = "0.5.0"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 num-traits = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ reqwasm = "0.5.0"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 num-traits = "0.2.15"
+getrandom = "0.2.7"
 
 arpy = { git = "https://github.com/simon-bourne/arpy" }
 arpy-reqwasm = { git = "https://github.com/simon-bourne/arpy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,5 +85,5 @@ arpy-axum = { git = "https://github.com/simon-bourne/arpy" }
 
 # test dependencies
 wasm-bindgen-test = "0.3.28"
-criterion = "0.4.0"
+criterion = { version = "0.4.0", default-features = false }
 trybuild = "1.0.76"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ async-recursion = "1.0.0"
 silkenweb-htmx-axum = { path = "packages/htmx-axum" }
 web-log = "1.0.1"
 rand = "0.8.5"
-getrandom = "0.2.7"
 serde_json = "1.0.85"
 parse-display = "0.8.0"
 silkenweb-bootstrap = { path = "packages/bootstrap" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,22 @@ opt-level = "z"
 [profile.bench]
 opt-level = 3
 
+[workspace.package]
+# The version is used by all published crates however it is not updated for the
+# internal silkenweb dependencies where it has to be updated manually.
+version = "0.4.0"
+
 # Defines the versions for all the workspace dependencies, including examples
 # but does not specify features, which is done in each crate as needed
 [workspace.dependencies]
 
 # main dependencies
+silkenweb = { path = "packages/silkenweb" }
+silkenweb-base = { path = "packages/base", version = "0.4.0" }
+silkenweb-signals-ext = { path = "packages/signals-ext", version = "0.4.0" }
+silkenweb-macros = { path = "packages/macros", version = "0.4.0" }
+silkenweb-tauri-proc-macro = { path = "packages/tauri-proc-macro", version = "0.4.0" }
+
 js-sys = "0.3.60"
 web-sys = "0.3.60"
 wasm-bindgen = "=0.2.84"
@@ -22,11 +33,6 @@ wasm-bindgen-futures = "0.4.33"
 cssparser = "0.29.6"
 lightningcss = "=1.0.0-alpha.42"
 itertools = "0.10.5"
-silkenweb = { path = "packages/silkenweb" }
-silkenweb-base = { path = "packages/base", version = "0.4.0" }
-silkenweb-signals-ext = { path = "packages/signals-ext", version = "0.4.0" }
-silkenweb-macros = { path = "packages/macros", version = "0.4.0" }
-silkenweb-tauri-proc-macro = { path = "packages/tauri-proc-macro", version = "0.4.0" }
 async-trait = "0.1.66"
 axum = "0.6.10"
 serde = "1.0.154"

--- a/examples/animation/Cargo.toml
+++ b/examples/animation/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
-num-traits = "0.2.15"
-wasm-bindgen = "=0.2.84"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }
+num-traits = { workspace = true }
+wasm-bindgen = { workspace = true }

--- a/examples/async-http-request/Cargo.toml
+++ b/examples/async-http-request/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-futures-signals = "0.3.24"
-reqwasm = "0.4.1"
-silkenweb = { path = "../../packages/silkenweb" }
+futures-signals = { workspace = true }
+reqwasm = { workspace = true }
+silkenweb = { workspace = true }

--- a/examples/bootstrap/Cargo.toml
+++ b/examples/bootstrap/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-silkenweb-bootstrap = { path = "../../packages/bootstrap"}
+silkenweb = { workspace = true }
+silkenweb-bootstrap = { workspace = true }

--- a/examples/client-server/Cargo.toml
+++ b/examples/client-server/Cargo.toml
@@ -6,18 +6,19 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
-arpy = { git = "https://github.com/simon-bourne/arpy" }
-serde = "1.0.152"
-futures = "0.3.26"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }
+arpy = { workspace = true }
+serde = { workspace = true }
+futures = { workspace = true }
+# TODO: unify with workspace version
 reqwasm = "0.5.0"
-arpy-reqwasm = { git = "https://github.com/simon-bourne/arpy" }
+arpy-reqwasm = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
-axum = "0.6.4"
-tokio = "1.25.0"
-arpy-server = { git = "https://github.com/simon-bourne/arpy" }
-arpy-axum = { git = "https://github.com/simon-bourne/arpy" }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+axum = { workspace = true }
+tokio = { workspace = true }
+arpy-server = { workspace = true }
+arpy-axum = { workspace = true }

--- a/examples/client-server/Cargo.toml
+++ b/examples/client-server/Cargo.toml
@@ -11,8 +11,7 @@ futures-signals = { workspace = true }
 arpy = { workspace = true }
 serde = { workspace = true }
 futures = { workspace = true }
-# TODO: unify with workspace version
-reqwasm = "0.5.0"
+reqwasm = { workspace = true }
 arpy-reqwasm = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/examples/component/Cargo.toml
+++ b/examples/component/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
+silkenweb = { workspace = true }

--- a/examples/counter-list/Cargo.toml
+++ b/examples/counter-list/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }

--- a/examples/css-modules/Cargo.toml
+++ b/examples/css-modules/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }

--- a/examples/css-modules/Cargo.toml
+++ b/examples/css-modules/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 silkenweb = { workspace = true }
-futures-signals = { workspace = true }

--- a/examples/drag-and-drop/Cargo.toml
+++ b/examples/drag-and-drop/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-gloo-console = "0.2.3"
-silkenweb = { path = "../../packages/silkenweb" }
+gloo-console = { workspace = true }
+silkenweb = { workspace = true }
 web-sys = { version = "0.3.60", features = ["DataTransfer"] }

--- a/examples/element-handle/Cargo.toml
+++ b/examples/element-handle/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }

--- a/examples/hackernews-clone/Cargo.toml
+++ b/examples/hackernews-clone/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-futures = "0.3.21"
-futures-signals = "0.3.24"
-reqwasm = "0.4.1"
-serde = "1.0.136"
-silkenweb = { path = "../../packages/silkenweb" }
-chrono = { version = "0.4.19", features = ["serde", "wasmbind"] } 
-timeago = "0.3.0"
-async-recursion = "1.0.0"
+futures = { workspace = true }
+futures-signals = { workspace = true }
+reqwasm = { workspace = true }
+serde = { workspace = true }
+silkenweb = { workspace = true }
+chrono = { workspace = true, features = ["serde", "wasmbind"] }
+timeago = { workspace = true }
+async-recursion = { workspace = true }

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
+silkenweb = { workspace = true }

--- a/examples/htmx-axum/Cargo.toml
+++ b/examples/htmx-axum/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-silkenweb-htmx-axum = { path = "../../packages/htmx-axum" }
-serde = "1.0.152"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
-axum = { version = "0.6.4", features = ["headers"] }
-tokio = { version = "1.25.0", features = ["full"] }
+silkenweb = { workspace = true }
+silkenweb-htmx-axum = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+axum = { workspace = true, features = ["headers"] }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/hydration/Cargo.toml
+++ b/examples/hydration/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
-web-log = "1.0.1"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }
+web-log = { workspace = true }

--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -10,3 +10,4 @@ silkenweb = { workspace = true, features = ["weak-refs"] }
 futures-signals = { workspace = true }
 wasm-bindgen = { workspace = true, features = ["enable-interning"] }
 rand = { workspace = true, features = ["small_rng"] }
+getrandom = { workspace = true, features = ["js"] }

--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -8,7 +8,5 @@ publish = false
 [dependencies]
 silkenweb = { workspace = true, features = ["weak-refs"] }
 futures-signals = { workspace = true }
-js-sys = { workspace = true }
 wasm-bindgen = { workspace = true, features = ["enable-interning"] }
 rand = { workspace = true, features = ["small_rng"] }
-getrandom = { workspace = true, features = ["js"] }

--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb", features = ["weak-refs"] }
-futures-signals = "0.3.31"
-js-sys = "0.3.60"
-wasm-bindgen = { version = "=0.2.84", features = ["enable-interning"] }
-rand = { version = "0.8.5", features = ["small_rng"] }
-getrandom = { version = "0.2.7", features = ["js"] }
+silkenweb = { workspace = true, features = ["weak-refs"] }
+futures-signals = { workspace = true }
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true, features = ["enable-interning"] }
+rand = { workspace = true, features = ["small_rng"] }
+getrandom = { workspace = true, features = ["js"] }

--- a/examples/reactive-styles/Cargo.toml
+++ b/examples/reactive-styles/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }

--- a/examples/reactive-styles/Cargo.toml
+++ b/examples/reactive-styles/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 silkenweb = { workspace = true }
-futures-signals = { workspace = true }

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 silkenweb = { workspace = true }
-futures-signals = { workspace = true }

--- a/examples/shadow-root/Cargo.toml
+++ b/examples/shadow-root/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
+silkenweb = { workspace = true }

--- a/examples/ssr/Cargo.toml
+++ b/examples/ssr/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -9,11 +9,9 @@ publish = false
 silkenweb = { workspace = true }
 silkenweb-signals-ext = { workspace = true }
 futures-signals = { workspace = true }
-js-sys = { workspace = true }
 derive_more = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
-discard = { workspace = true }
 wasm-bindgen = { workspace = true }
 web-sys = { workspace = true, features = ["console"] }
 

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -6,22 +6,20 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-silkenweb-signals-ext = { path = "../../packages/signals-ext" }
-futures-signals = "0.3.31"
-js-sys = "0.3.60"
-derive_more = "0.99.17"
-serde = { version = "1.0.145", features = ["derive", "rc"] }
-serde_json = "1.0.85"
-discard = "1.0.4"
-wasm-bindgen = "=0.2.84"
+silkenweb = { workspace = true }
+silkenweb-signals-ext = { workspace = true }
+futures-signals = { workspace = true }
+js-sys = { workspace = true }
+derive_more = { workspace = true }
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json = { workspace = true }
+discard = { workspace = true }
+wasm-bindgen = { workspace = true }
+web-sys = { workspace = true, features = ["console"] }
 
-[dependencies.web-sys]
-version = "0.3.60"
-features = ["console"]
 
 [dev-dependencies]
-criterion = { version = "0.4.0", default-features = false }
+criterion = { workspace = true, default-features = false }
 
 [[bench]]
 name = "ssr"

--- a/examples/web-components-wrapper/Cargo.toml
+++ b/examples/web-components-wrapper/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 readme = true
 
 [dependencies]
-silkenweb = { path = "../../packages/silkenweb" }
-futures-signals = "0.3.31"
-web-sys = "0.3.60"
-parse-display = "0.8.0"
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }
+web-sys = { workspace = true }
+parse-display = { workspace = true }

--- a/packages/base/Cargo.toml
+++ b/packages/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-base"
-version = "0.4.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 description = "Base crate for Silkenweb"

--- a/packages/base/Cargo.toml
+++ b/packages/base/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["gui", "web-programming"]
 keywords = ["reactive", "web", "html", "browser", "dom"]
 
 [dependencies]
-wasm-bindgen = "=0.2.84"
-js-sys = "0.3.60"
-cssparser = "0.29.6"
-lightningcss = "=1.0.0-alpha.42"
-itertools = "0.10.5"
+wasm-bindgen = { workspace = true }
+js-sys = { workspace = true }
+cssparser = { workspace = true }
+lightningcss = { workspace = true }
+itertools = { workspace = true }
 
 [dependencies.web-sys]
-version = "0.3.60"
+workspace = true
 features = [
     "Document",
     "Element",

--- a/packages/bootstrap/Cargo.toml
+++ b/packages/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-bootstrap"
-version = "0.1.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 publish = false

--- a/packages/bootstrap/Cargo.toml
+++ b/packages/bootstrap/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-silkenweb = { path = "../silkenweb" }
-silkenweb-bootstrap-macros = { path = "macros" }
-futures-signals = "0.3.31"
-derive_more = "0.99.17"
+silkenweb = { workspace = true }
+silkenweb-bootstrap-macros = { workspace = true }
+futures-signals = { workspace = true }
+derive_more = { workspace = true }

--- a/packages/bootstrap/macros/Cargo.toml
+++ b/packages/bootstrap/macros/Cargo.toml
@@ -15,9 +15,9 @@ keywords = ["css"]
 proc-macro = true
 
 [dependencies]
-silkenweb-base = { path = "../../base", version = "0.4.0" }
-syn = { version = "1.0.86", features = ["full"] }
-proc-macro-error = "1.0.4"
-quote = "1.0.15"
-proc-macro2 = "1.0.36"
-heck = "0.4.0"
+silkenweb-base = { workspace = true }
+syn = { workspace = true, features = ["full"] }
+proc-macro-error = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+heck = { workspace = true }

--- a/packages/bootstrap/macros/Cargo.toml
+++ b/packages/bootstrap/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-bootstrap-macros"
-version = "0.4.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 description = "Silkenweb Bootstrap proc macros"

--- a/packages/htmx-axum/Cargo.toml
+++ b/packages/htmx-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-htmx-axum"
-version = "0.1.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 publish = false

--- a/packages/htmx-axum/Cargo.toml
+++ b/packages/htmx-axum/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-trait = "0.1.66"
-axum = { version = "0.6.10", features = ["headers"] }
-serde = "1.0.154"
-serde_urlencoded = "0.7.1"
-silkenweb = { path = "../silkenweb" }
+async-trait = { workspace = true }
+axum = { workspace = true, features = ["headers"] }
+serde = { workspace = true }
+serde_urlencoded = { workspace = true }
+silkenweb = { workspace = true }

--- a/packages/macros/Cargo.toml
+++ b/packages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-macros"
-version = "0.4.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 description = "Silkenweb proc macros"

--- a/packages/macros/Cargo.toml
+++ b/packages/macros/Cargo.toml
@@ -18,12 +18,12 @@ proc-macro = true
 sass = ["dep:grass"]
 
 [dependencies]
-silkenweb-base = { path = "../base", version = "0.4.0" }
-syn = { version = "1.0.86", features = ["full"] }
-cssparser = "0.29.6"
-proc-macro-error = "1.0.4"
-quote = "1.0.15"
-proc-macro2 = "1.0.36"
-lightningcss = "=1.0.0-alpha.42"
-grass = { version = "0.12.4", optional = true }
-derive_more = "0.99.17"
+silkenweb-base = { workspace = true }
+syn = { workspace = true, features = ["full"] }
+cssparser = { workspace = true }
+proc-macro-error = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+lightningcss = { workspace = true }
+grass = { workspace = true, optional = true }
+derive_more = { workspace = true }

--- a/packages/macros/Cargo.toml
+++ b/packages/macros/Cargo.toml
@@ -20,7 +20,6 @@ sass = ["dep:grass"]
 [dependencies]
 silkenweb-base = { workspace = true }
 syn = { workspace = true, features = ["full"] }
-cssparser = { workspace = true }
 proc-macro-error = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/packages/signals-ext/Cargo.toml
+++ b/packages/signals-ext/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["gui"]
 keywords = ["reactive"]
 
 [dependencies]
-futures-signals = "0.3.31"
-pin-project = "1.0.12"
-paste = "1.0.9"
+futures-signals = { workspace = true }
+pin-project = { workspace = true }
+paste = { workspace = true }

--- a/packages/signals-ext/Cargo.toml
+++ b/packages/signals-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-signals-ext"
-version = "0.4.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 description = "Extras for futures-signals"

--- a/packages/silkenweb/Cargo.toml
+++ b/packages/silkenweb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb"
-version = "0.4.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 description = "A library for building web apps"

--- a/packages/silkenweb/Cargo.toml
+++ b/packages/silkenweb/Cargo.toml
@@ -18,23 +18,23 @@ declarative-shadow-dom = []
 sass = ["silkenweb-macros/sass"]
 
 [dependencies]
-discard = "1.0.4"
-js-sys = "0.3.60"
-futures = "0.3.24"
-caseless = "0.2.1"
-html-escape = "0.2.9"
-indexmap = "1.8.0"
-itertools = "0.10.5"
-silkenweb-base = { path = "../base", version = "0.4.0" }
-silkenweb-signals-ext = { path = "../signals-ext", version = "0.4.0" }
-silkenweb-macros = { path = "../macros", version = "0.4.0" }
-paste = "1.0.9"
-wasm-bindgen = "=0.2.84"
-futures-signals = "0.3.31"
-console_error_panic_hook = "0.1.7"
+discard = { workspace = true }
+js-sys = { workspace = true }
+futures = { workspace = true }
+caseless = { workspace = true }
+html-escape = { workspace = true }
+indexmap = { workspace = true }
+itertools = { workspace = true }
+silkenweb-base = { workspace = true }
+silkenweb-signals-ext = { workspace = true }
+silkenweb-macros = { workspace = true }
+paste = { workspace = true }
+wasm-bindgen = { workspace = true }
+futures-signals = { workspace = true }
+console_error_panic_hook = { workspace = true }
 
 [dependencies.web-sys]
-version = "0.3.60"
+workspace = true
 features = [
     "AnimationEvent",
     "Attr",
@@ -191,16 +191,16 @@ features = [
 ]
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-wasm-bindgen-futures = "0.4.33"
+wasm-bindgen-futures = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.25.0", features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.28"
-itertools = "0.10.3"
-criterion = { version = "0.4.0", default-features = false }
-trybuild = "1.0.76"
+wasm-bindgen-test = { workspace = true }
+itertools = { workspace = true }
+criterion = { workspace = true, default-features = false }
+trybuild = { workspace = true }
 
 [[bench]]
 name = "ssr"

--- a/packages/tauri-proc-macro/Cargo.toml
+++ b/packages/tauri-proc-macro/Cargo.toml
@@ -18,4 +18,3 @@ proc-macro = true
 syn = { workspace = true, features = ["full"] }
 proc-macro-error = { workspace = true }
 quote = { workspace = true }
-proc-macro2 = { workspace = true }

--- a/packages/tauri-proc-macro/Cargo.toml
+++ b/packages/tauri-proc-macro/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["silkenweb", "tauri"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.86", features = ["full"] }
-proc-macro-error = "1.0.4"
-quote = "1.0.15"
-proc-macro2 = "1.0.36"
+syn = { workspace = true, features = ["full"] }
+proc-macro-error = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/packages/tauri-proc-macro/Cargo.toml
+++ b/packages/tauri-proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-tauri-proc-macro"
-version = "0.4.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 description = "Silkenweb Tauri integration"

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "silkenweb-tauri"
-version = "0.4.0"
+version = { workspace = true }
 authors = ["Simon Bourne <simonbourne@gmail.com>"]
 edition = "2021"
 description = "Silkenweb Tauri integration"

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["gui"]
 keywords = ["silkenweb", "tauri"]
 
 [dependencies]
-silkenweb-tauri-proc-macro = { version = "0.4.0", path = "../tauri-proc-macro" }
-js-sys = "0.3.60"
-wasm-bindgen = "=0.2.84"
-wasm-bindgen-futures = "0.4.33"
-static_assertions = "1.1.0"
-serde-wasm-bindgen = "0.4.5"
+silkenweb-tauri-proc-macro = { workspace = true }
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+static_assertions = { workspace = true }
+serde-wasm-bindgen = { workspace = true }

--- a/packages/xtask/Cargo.toml
+++ b/packages/xtask/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = "4.1.8"
-xtask-base = { git = "https://github.com/simon-bourne/rust-xtask-base" }
-xshell = "0.1.17"
-duct = "0.13.5"
-scopeguard = "1.1.0"
-itertools = "0.10.3"
+clap = { workspace = true }
+xtask-base = { workspace = true }
+xshell = { workspace = true }
+duct = { workspace = true }
+scopeguard = { workspace = true }
+itertools = { workspace = true }


### PR DESCRIPTION
I tested with `cargo test` and `cargo publish --dry-run`: all ok except for _packages/macros_ and _packages/silkenweb_ which fails the publish build. From what I understand, the errors are due to some silkenweb crate versioning issues. Releasing a new version should fix it.