### PR TITLE
Portable timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reactive stylesheets.
 - Drag and drop events.
 - `css!` supports Sass.
+- Portable timers with `time::{sleep, interval}`
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "silkenweb-example-timers"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "futures-signals",
+ "silkenweb",
+ "tokio",
+]
+
+[[package]]
 name = "silkenweb-example-web-components-wrapper"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ source = "git+https://github.com/simon-bourne/arpy#e602e8ed6443535c008c3e4d8bf2e
 dependencies = [
  "heck",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -502,7 +502,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -717,7 +717,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smallvec",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -727,7 +727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -754,7 +754,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -771,7 +771,7 @@ checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -812,7 +812,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -919,7 +919,7 @@ checksum = "5109f6bc9cd57feda665da326f3f6c57e0498c8fe9f7d12d7b8abc96719ca91b"
 dependencies = [
  "execute-command-tokens",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1005,7 +1005,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1142,6 +1142,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1391,7 +1403,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "ra_ap_syntax",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1756,7 +1768,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1826,7 +1838,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1911,7 +1923,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1934,22 +1946,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1985,7 +1997,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -2008,9 +2020,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2032,14 +2044,14 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -2377,7 +2389,7 @@ checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2513,7 +2525,7 @@ checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2608,15 +2620,18 @@ dependencies = [
  "discard",
  "futures",
  "futures-signals",
+ "gloo-timers",
  "html-escape",
  "indexmap",
  "itertools",
  "js-sys",
  "paste",
+ "pin-project",
  "silkenweb-base",
  "silkenweb-macros",
  "silkenweb-signals-ext",
  "tokio",
+ "tokio-stream",
  "trybuild",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2663,7 +2678,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "silkenweb-base",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2888,7 +2903,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "silkenweb-base",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2919,7 +2934,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3014,7 +3029,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3025,7 +3040,7 @@ checksum = "bafede0d0a2f21910f36d47b1558caae3076ed80f6f3ad0fc85a91e6ba7e5938"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3033,6 +3048,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3092,7 +3118,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3179,14 +3205,14 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3273,7 +3299,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3499,7 +3525,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -3533,7 +3559,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/examples/timers/Cargo.toml
+++ b/examples/timers/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "silkenweb-example-timers"
+version = "0.1.0"
+authors = ["Simon Bourne <simonbourne@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+silkenweb = { workspace = true }
+futures-signals = { workspace = true }
+futures = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }

--- a/examples/timers/index.html
+++ b/examples/timers/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head profile="http://www.w3.org/2005/10/profile">
+    <meta charset="utf-8" />
+    <title>Silkenweb Example: Timers</title>
+	<link rel="rust" data-trunk data-wasm-opt="z" data-weak-refs />
+    <base data-trunk-public-url/>
+</head>
+
+<body>
+    <div id="app"></div>
+</body>
+
+</html>

--- a/examples/timers/src/main.rs
+++ b/examples/timers/src/main.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+use futures::stream::StreamExt;
+use futures_signals::signal::{Mutable, SignalExt};
+use silkenweb::{cfg_browser, elements::html::*, prelude::*, task::spawn_local, time, value::Sig};
+
+fn app() -> Div {
+    let ticks = Mutable::new(0);
+    // Tick every tenth of a second.
+    let mut interval = time::interval(Duration::from_millis(100));
+    // Throttle ticks so they only happen every second.
+    let ticks_signal = ticks
+        .signal()
+        .throttle(|| time::sleep(Duration::from_secs(1)));
+
+    spawn_local(async move {
+        while interval.next().await.is_some() {
+            ticks.set(ticks.get() + 1);
+        }
+    });
+
+    div().child(p().text(Sig(ticks_signal.map(|i| format!("{i}")))))
+}
+
+#[cfg_browser(true)]
+fn main() {
+    mount("app", app());
+}
+
+#[cfg_browser(false)]
+#[tokio::main]
+async fn main() {
+    use silkenweb::task;
+
+    task::server::scope(async {
+        let app = app().freeze();
+
+        for _i in 0..30 {
+            task::render_now().await;
+            println!("{app}");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+}

--- a/packages/silkenweb/Cargo.toml
+++ b/packages/silkenweb/Cargo.toml
@@ -32,6 +32,7 @@ paste = "1.0.9"
 wasm-bindgen = "=0.2.84"
 futures-signals = "0.3.31"
 console_error_panic_hook = "0.1.7"
+pin-project = "1.1.2"
 
 [dependencies.web-sys]
 version = "0.3.60"
@@ -192,9 +193,11 @@ features = [
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = "0.4.33"
+gloo-timers = { version = "0.2.6", features = ["futures"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.25.0", features = ["rt", "macros"] }
+tokio = { version = "1.25.0", features = ["rt", "macros", "time"] }
+tokio-stream = { version = "0.1.14", features = ["time"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.28"

--- a/packages/silkenweb/src/lib.rs
+++ b/packages/silkenweb/src/lib.rs
@@ -299,6 +299,7 @@ pub mod node;
 pub mod router;
 pub mod storage;
 pub mod task;
+pub mod time;
 
 /// Commonly used imports, all in one place.
 pub mod prelude {

--- a/packages/silkenweb/src/time.rs
+++ b/packages/silkenweb/src/time.rs
@@ -101,21 +101,22 @@ mod arch {
 }
 
 /// A stream that yields `()` periodically.
-/// 
-/// Yield `()` every `period`. The first value will be produced after a delay of `period`.
+///
+/// Yield `()` every `period`. The first value will be produced after a delay of
+/// `period`.
 ///
 /// # Panics
-/// 
+///
 /// If `duration` can't be converted into a [`u32`] in milliseconds.
 pub use arch::interval;
 /// Sleep for `duration`.
-/// 
+///
 /// # Panics
-/// 
+///
 /// If `duration` can't be converted into a [`u32`] in milliseconds.
 pub use arch::sleep;
 /// [`Stream`] for [`interval`]
-/// 
+///
 /// [`Stream`]: futures::Stream
 pub use arch::Interval;
 /// [`Future`] for [`sleep`]

--- a/packages/silkenweb/src/time.rs
+++ b/packages/silkenweb/src/time.rs
@@ -1,3 +1,4 @@
+//! Utilities for tacking time.
 use silkenweb_macros::cfg_browser;
 
 #[cfg_browser(true)]
@@ -21,8 +22,8 @@ mod arch {
         }
     }
 
-    pub fn sleep(dur: Duration) -> Sleep {
-        Sleep(gloo_timers::future::sleep(dur))
+    pub fn sleep(duration: Duration) -> Sleep {
+        Sleep(gloo_timers::future::sleep(duration))
     }
 
     #[derive(Debug)]
@@ -71,8 +72,8 @@ mod arch {
         }
     }
 
-    pub fn sleep(dur: Duration) -> Sleep {
-        Sleep(tokio::time::sleep(dur))
+    pub fn sleep(duration: Duration) -> Sleep {
+        Sleep(tokio::time::sleep(duration))
     }
 
     #[derive(Debug)]
@@ -99,5 +100,25 @@ mod arch {
     }
 }
 
-// TODO: Doc
-pub use arch::{interval, sleep, Interval, Sleep};
+/// A stream that yields `()` periodically.
+/// 
+/// Yield `()` every `period`. The first value will be produced after a delay of `period`.
+///
+/// # Panics
+/// 
+/// If `duration` can't be converted into a [`u32`] in milliseconds.
+pub use arch::interval;
+/// Sleep for `duration`.
+/// 
+/// # Panics
+/// 
+/// If `duration` can't be converted into a [`u32`] in milliseconds.
+pub use arch::sleep;
+/// [`Stream`] for [`interval`]
+/// 
+/// [`Stream`]: futures::Stream
+pub use arch::Interval;
+/// [`Future`] for [`sleep`]
+///
+/// [`Future`]: std::future::Future
+pub use arch::Sleep;

--- a/packages/silkenweb/src/time.rs
+++ b/packages/silkenweb/src/time.rs
@@ -1,0 +1,103 @@
+use silkenweb_macros::cfg_browser;
+
+#[cfg_browser(true)]
+mod arch {
+    use std::{future::Future, pin::Pin, task, time::Duration};
+
+    use futures::Stream;
+    use gloo_timers::future::{IntervalStream, TimeoutFuture};
+    use pin_project::pin_project;
+    use wasm_bindgen::UnwrapThrowExt;
+
+    #[derive(Debug)]
+    #[pin_project]
+    pub struct Sleep(#[pin] TimeoutFuture);
+
+    impl Future for Sleep {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+            self.project().0.poll(cx)
+        }
+    }
+
+    pub fn sleep(dur: Duration) -> Sleep {
+        Sleep(gloo_timers::future::sleep(dur))
+    }
+
+    #[derive(Debug)]
+    #[pin_project]
+    pub struct Interval(#[pin] IntervalStream);
+
+    impl Stream for Interval {
+        type Item = ();
+
+        fn poll_next(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+        ) -> task::Poll<Option<Self::Item>> {
+            self.project().0.poll_next(cx)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (std::usize::MAX, None)
+        }
+    }
+
+    pub fn interval(period: Duration) -> Interval {
+        let period_ms = u32::try_from(period.as_millis())
+            .expect_throw("failed to cast the duration into a u32 with Duration::as_millis.");
+        Interval(IntervalStream::new(period_ms))
+    }
+}
+
+#[cfg_browser(false)]
+mod arch {
+    use std::{future::Future, pin::Pin, task, time::Duration};
+
+    use futures::{stream::Skip, Stream, StreamExt};
+    use pin_project::pin_project;
+    use tokio_stream::wrappers::IntervalStream;
+
+    #[derive(Debug)]
+    #[pin_project]
+    pub struct Sleep(#[pin] tokio::time::Sleep);
+
+    impl Future for Sleep {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+            self.project().0.poll(cx)
+        }
+    }
+
+    pub fn sleep(dur: Duration) -> Sleep {
+        Sleep(tokio::time::sleep(dur))
+    }
+
+    #[derive(Debug)]
+    #[pin_project]
+    pub struct Interval(#[pin] Skip<IntervalStream>);
+
+    impl Stream for Interval {
+        type Item = ();
+
+        fn poll_next(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+        ) -> task::Poll<Option<Self::Item>> {
+            self.project().0.poll_next(cx).map(|_| Some(()))
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (std::usize::MAX, None)
+        }
+    }
+
+    pub fn interval(period: Duration) -> Interval {
+        Interval(IntervalStream::new(tokio::time::interval(period)).skip(1))
+    }
+}
+
+// TODO: Doc
+pub use arch::{interval, sleep, Interval, Sleep};


### PR DESCRIPTION
Provide `time::{sleep, interval}`.

Fixes #59